### PR TITLE
add shebang so docker doesnt throw exec error

### DIFF
--- a/couchbase-server/configure-node.sh
+++ b/couchbase-server/configure-node.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -m
 
 /entrypoint.sh couchbase-server &
@@ -10,4 +12,3 @@ curl -v http://127.0.0.1:8091/settings/web -d port=8091 -d username=Administrato
 curl -v -u Administrator:password -X POST http://127.0.0.1:8091/sampleBuckets/install -d '["travel-sample"]'
 
 fg 1
-

--- a/couchbase/configure-node.sh
+++ b/couchbase/configure-node.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -x
 set -m
 
@@ -39,4 +41,3 @@ if [ "$TYPE" = "WORKER" ]; then
 fi;
 
 fg 1
-


### PR DESCRIPTION
Missing shebang in configure script causes docker to throw exec errors.